### PR TITLE
Change interface to use a comparison function

### DIFF
--- a/comparer.go
+++ b/comparer.go
@@ -1,0 +1,28 @@
+package goroutree
+
+import "errors"
+
+var NotComparable error = errors.New("Not Comparable")
+
+type Comparer interface {
+	// Compare yourself to something.  If the values are not comparable,
+	// returns negative if the first argument is “less” than the second, zero
+	// if they are “equal”, and positive if the first argument is “greater”
+	// returns 0, and an error of "Not Comparable" if not comparable
+	Compare(interface{}) (int, error)
+}
+
+type Int int
+
+func (i Int) Compare(value interface{}) (int, error) {
+	intValue, ok := value.(Int)
+	if !ok {
+		return 0, NotComparable
+	}
+	if i < intValue {
+		return -1, nil
+	} else if i == intValue {
+		return 0, nil
+	}
+	return 1, nil
+}

--- a/comparer_test.go
+++ b/comparer_test.go
@@ -1,0 +1,68 @@
+package goroutree_test
+
+import (
+	"testing"
+
+	"github.com/ScottMansfield/goroutree"
+)
+
+func TestInt(t *testing.T) {
+	var a, b, c goroutree.Int = 4, 5, 6
+
+	t.Run("Less", func(t *testing.T) {
+		// Transitive
+		if i, _ := a.Compare(b); i != -1 {
+			t.Errorf("Expected %d to be less than %d and return -1", a, b)
+		}
+
+		if i, _ := b.Compare(c); i != -1 {
+			t.Errorf("Expected %d to be less than %d and return -1", b, c)
+		}
+
+		if i, _ := a.Compare(c); i != -1 {
+			t.Errorf("Expected %d to be less than %d and return -1", a, c)
+		}
+	})
+	t.Run("Equal", func(t *testing.T) {
+		if i, _ := a.Compare(a); i != 0 {
+			t.Errorf("Expected %d to be less than %d and return 0", a, a)
+		}
+
+		if i, _ := b.Compare(b); i != 0 {
+			t.Errorf("Expected %d to be less than %d and return 0", b, b)
+		}
+
+		if i, _ := c.Compare(c); i != 0 {
+			t.Errorf("Expected %d to be less than %d and return 0", c, c)
+		}
+	})
+	t.Run("Greater", func(t *testing.T) {
+		// Transitive
+
+		if i, _ := c.Compare(b); i != 1 {
+			t.Errorf("Expected %d to be less than %d and return 1", c, b)
+		}
+		if i, _ := b.Compare(a); i != 1 {
+			t.Errorf("Expected %d to be less than %d and return 1", b, a)
+		}
+		if i, _ := c.Compare(a); i != 1 {
+			t.Errorf("Expected %d to be less than %d and return 1", c, a)
+		}
+
+	})
+}
+
+type NotInt string
+
+func (NotInt) Compare(interface{}) (int, error) {
+	return 0, nil
+}
+
+func TestIncompatable(t *testing.T) {
+	var anInt goroutree.Int = 4
+	var notAnInt NotInt = "Not An Int"
+
+	if i, err := anInt.Compare(notAnInt); i != 0 {
+		t.Errorf("Expected %d to not compare to %d and return 0 and \"%s\", got %d and \"%s\"", anInt, notAnInt, goroutree.NotComparable.Error(), i, err.Error())
+	}
+}

--- a/goroutree_test.go
+++ b/goroutree_test.go
@@ -28,7 +28,7 @@ func TestInsert(t *testing.T) {
 
 		boolreschan := make(chan bool)
 
-		g.Insert(boolreschan, 5)
+		g.Insert(boolreschan, goroutree.Int(5))
 
 		b := <-boolreschan
 		if b != true {
@@ -54,14 +54,14 @@ func TestInsert(t *testing.T) {
 
 			boolreschan := make(chan bool)
 
-			g.Insert(boolreschan, 5)
+			g.Insert(boolreschan, goroutree.Int(5))
 
 			b := <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 4)
+			g.Insert(boolreschan, goroutree.Int(4))
 
 			b = <-boolreschan
 			if b != true {
@@ -86,14 +86,14 @@ func TestInsert(t *testing.T) {
 
 			boolreschan := make(chan bool)
 
-			g.Insert(boolreschan, 5)
+			g.Insert(boolreschan, goroutree.Int(5))
 
 			b := <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 6)
+			g.Insert(boolreschan, goroutree.Int(6))
 
 			b = <-boolreschan
 			if b != true {
@@ -118,14 +118,14 @@ func TestInsert(t *testing.T) {
 
 			boolreschan := make(chan bool)
 
-			g.Insert(boolreschan, 5)
+			g.Insert(boolreschan, goroutree.Int(5))
 
 			b := <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 5)
+			g.Insert(boolreschan, goroutree.Int(5))
 
 			b = <-boolreschan
 			if b != false {
@@ -152,21 +152,21 @@ func TestInsert(t *testing.T) {
 
 			boolreschan := make(chan bool)
 
-			g.Insert(boolreschan, 5)
+			g.Insert(boolreschan, goroutree.Int(5))
 
 			b := <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 4)
+			g.Insert(boolreschan, goroutree.Int(4))
 
 			b = <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 6)
+			g.Insert(boolreschan, goroutree.Int(6))
 
 			b = <-boolreschan
 			if b != true {
@@ -191,21 +191,21 @@ func TestInsert(t *testing.T) {
 
 			boolreschan := make(chan bool)
 
-			g.Insert(boolreschan, 6)
+			g.Insert(boolreschan, goroutree.Int(6))
 
 			b := <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 5)
+			g.Insert(boolreschan, goroutree.Int(5))
 
 			b = <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 4)
+			g.Insert(boolreschan, goroutree.Int(4))
 
 			b = <-boolreschan
 			if b != true {
@@ -230,21 +230,21 @@ func TestInsert(t *testing.T) {
 
 			boolreschan := make(chan bool)
 
-			g.Insert(boolreschan, 4)
+			g.Insert(boolreschan, goroutree.Int(4))
 
 			b := <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 5)
+			g.Insert(boolreschan, goroutree.Int(5))
 
 			b = <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 6)
+			g.Insert(boolreschan, goroutree.Int(6))
 
 			b = <-boolreschan
 			if b != true {
@@ -269,21 +269,21 @@ func TestInsert(t *testing.T) {
 
 			boolreschan := make(chan bool)
 
-			g.Insert(boolreschan, 4)
+			g.Insert(boolreschan, goroutree.Int(4))
 
 			b := <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 6)
+			g.Insert(boolreschan, goroutree.Int(6))
 
 			b = <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 5)
+			g.Insert(boolreschan, goroutree.Int(5))
 
 			b = <-boolreschan
 			if b != true {
@@ -308,21 +308,21 @@ func TestInsert(t *testing.T) {
 
 			boolreschan := make(chan bool)
 
-			g.Insert(boolreschan, 6)
+			g.Insert(boolreschan, goroutree.Int(6))
 
 			b := <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 4)
+			g.Insert(boolreschan, goroutree.Int(4))
 
 			b = <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 5)
+			g.Insert(boolreschan, goroutree.Int(5))
 
 			b = <-boolreschan
 			if b != true {
@@ -347,21 +347,21 @@ func TestInsert(t *testing.T) {
 
 			boolreschan := make(chan bool)
 
-			g.Insert(boolreschan, 4)
+			g.Insert(boolreschan, goroutree.Int(4))
 
 			b := <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 5)
+			g.Insert(boolreschan, goroutree.Int(5))
 
 			b = <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 4)
+			g.Insert(boolreschan, goroutree.Int(4))
 
 			b = <-boolreschan
 			if b != false {
@@ -386,21 +386,21 @@ func TestInsert(t *testing.T) {
 
 			boolreschan := make(chan bool)
 
-			g.Insert(boolreschan, 5)
+			g.Insert(boolreschan, goroutree.Int(5))
 
 			b := <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 4)
+			g.Insert(boolreschan, goroutree.Int(4))
 
 			b = <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 4)
+			g.Insert(boolreschan, goroutree.Int(4))
 
 			b = <-boolreschan
 			if b != false {
@@ -425,21 +425,21 @@ func TestInsert(t *testing.T) {
 
 			boolreschan := make(chan bool)
 
-			g.Insert(boolreschan, 4)
+			g.Insert(boolreschan, goroutree.Int(4))
 
 			b := <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 5)
+			g.Insert(boolreschan, goroutree.Int(5))
 
 			b = <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 5)
+			g.Insert(boolreschan, goroutree.Int(5))
 
 			b = <-boolreschan
 			if b != false {
@@ -475,21 +475,21 @@ func TestInsert(t *testing.T) {
 		boolreschan := make(chan bool, 15)
 
 		// create a balanced tree of 15 items
-		g.Insert(boolreschan, 7)
-		g.Insert(boolreschan, 3)
-		g.Insert(boolreschan, 1)
-		g.Insert(boolreschan, 0)
-		g.Insert(boolreschan, 2)
-		g.Insert(boolreschan, 5)
-		g.Insert(boolreschan, 4)
-		g.Insert(boolreschan, 6)
-		g.Insert(boolreschan, 11)
-		g.Insert(boolreschan, 9)
-		g.Insert(boolreschan, 8)
-		g.Insert(boolreschan, 10)
-		g.Insert(boolreschan, 13)
-		g.Insert(boolreschan, 12)
-		g.Insert(boolreschan, 14)
+		g.Insert(boolreschan, goroutree.Int(7))
+		g.Insert(boolreschan, goroutree.Int(3))
+		g.Insert(boolreschan, goroutree.Int(1))
+		g.Insert(boolreschan, goroutree.Int(0))
+		g.Insert(boolreschan, goroutree.Int(2))
+		g.Insert(boolreschan, goroutree.Int(5))
+		g.Insert(boolreschan, goroutree.Int(4))
+		g.Insert(boolreschan, goroutree.Int(6))
+		g.Insert(boolreschan, goroutree.Int(11))
+		g.Insert(boolreschan, goroutree.Int(9))
+		g.Insert(boolreschan, goroutree.Int(8))
+		g.Insert(boolreschan, goroutree.Int(10))
+		g.Insert(boolreschan, goroutree.Int(13))
+		g.Insert(boolreschan, goroutree.Int(12))
+		g.Insert(boolreschan, goroutree.Int(14))
 
 		for i := 0; i < 15; i++ {
 			b := <-boolreschan
@@ -517,7 +517,7 @@ func TestContains(t *testing.T) {
 	t.Run("Empty", func(t *testing.T) {
 		g := goroutree.New()
 		boolreschan := make(chan bool)
-		g.Contains(boolreschan, 4)
+		g.Contains(boolreschan, goroutree.Int(4))
 
 		b := <-boolreschan
 		if b != false {
@@ -529,14 +529,14 @@ func TestContains(t *testing.T) {
 			g := goroutree.New()
 			boolreschan := make(chan bool)
 
-			g.Insert(boolreschan, 4)
+			g.Insert(boolreschan, goroutree.Int(4))
 
 			b := <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Contains(boolreschan, 4)
+			g.Contains(boolreschan, goroutree.Int(4))
 
 			b = <-boolreschan
 			if b != true {
@@ -547,14 +547,14 @@ func TestContains(t *testing.T) {
 			g := goroutree.New()
 			boolreschan := make(chan bool)
 
-			g.Insert(boolreschan, 4)
+			g.Insert(boolreschan, goroutree.Int(4))
 
 			b := <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Contains(boolreschan, 5)
+			g.Contains(boolreschan, goroutree.Int(5))
 
 			b = <-boolreschan
 			if b != false {
@@ -568,21 +568,21 @@ func TestContains(t *testing.T) {
 				g := goroutree.New()
 				boolreschan := make(chan bool)
 
-				g.Insert(boolreschan, 4)
+				g.Insert(boolreschan, goroutree.Int(4))
 
 				b := <-boolreschan
 				if b != true {
 					t.Fatalf("Expected a true result from inserting")
 				}
 
-				g.Insert(boolreschan, 6)
+				g.Insert(boolreschan, goroutree.Int(6))
 
 				b = <-boolreschan
 				if b != true {
 					t.Fatalf("Expected a true result from inserting")
 				}
 
-				g.Contains(boolreschan, 4)
+				g.Contains(boolreschan, goroutree.Int(4))
 
 				b = <-boolreschan
 				if b != true {
@@ -594,21 +594,21 @@ func TestContains(t *testing.T) {
 					g := goroutree.New()
 					boolreschan := make(chan bool)
 
-					g.Insert(boolreschan, 4)
+					g.Insert(boolreschan, goroutree.Int(4))
 
 					b := <-boolreschan
 					if b != true {
 						t.Fatalf("Expected a true result from inserting")
 					}
 
-					g.Insert(boolreschan, 2)
+					g.Insert(boolreschan, goroutree.Int(2))
 
 					b = <-boolreschan
 					if b != true {
 						t.Fatalf("Expected a true result from inserting")
 					}
 
-					g.Contains(boolreschan, 2)
+					g.Contains(boolreschan, goroutree.Int(2))
 
 					b = <-boolreschan
 					if b != true {
@@ -619,21 +619,21 @@ func TestContains(t *testing.T) {
 					g := goroutree.New()
 					boolreschan := make(chan bool)
 
-					g.Insert(boolreschan, 4)
+					g.Insert(boolreschan, goroutree.Int(4))
 
 					b := <-boolreschan
 					if b != true {
 						t.Fatalf("Expected a true result from inserting")
 					}
 
-					g.Insert(boolreschan, 6)
+					g.Insert(boolreschan, goroutree.Int(6))
 
 					b = <-boolreschan
 					if b != true {
 						t.Fatalf("Expected a true result from inserting")
 					}
 
-					g.Contains(boolreschan, 6)
+					g.Contains(boolreschan, goroutree.Int(6))
 
 					b = <-boolreschan
 					if b != true {
@@ -647,14 +647,14 @@ func TestContains(t *testing.T) {
 				g := goroutree.New()
 				boolreschan := make(chan bool)
 
-				g.Insert(boolreschan, 4)
+				g.Insert(boolreschan, goroutree.Int(4))
 
 				b := <-boolreschan
 				if b != true {
 					t.Fatalf("Expected a true result from inserting")
 				}
 
-				g.Contains(boolreschan, 3)
+				g.Contains(boolreschan, goroutree.Int(3))
 
 				b = <-boolreschan
 				if b != false {
@@ -665,14 +665,14 @@ func TestContains(t *testing.T) {
 				g := goroutree.New()
 				boolreschan := make(chan bool)
 
-				g.Insert(boolreschan, 4)
+				g.Insert(boolreschan, goroutree.Int(4))
 
 				b := <-boolreschan
 				if b != true {
 					t.Fatalf("Expected a true result from inserting")
 				}
 
-				g.Contains(boolreschan, 5)
+				g.Contains(boolreschan, goroutree.Int(5))
 
 				b = <-boolreschan
 				if b != false {
@@ -687,7 +687,7 @@ func TestDelete(t *testing.T) {
 	t.Run("Empty", func(t *testing.T) {
 		g := goroutree.New()
 		boolreschan := make(chan bool)
-		g.Delete(boolreschan, 4)
+		g.Delete(boolreschan, goroutree.Int(4))
 
 		b := <-boolreschan
 		if b != false {
@@ -699,14 +699,14 @@ func TestDelete(t *testing.T) {
 			g := goroutree.New()
 			boolreschan := make(chan bool)
 
-			g.Insert(boolreschan, 4)
+			g.Insert(boolreschan, goroutree.Int(4))
 
 			b := <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Delete(boolreschan, 4)
+			g.Delete(boolreschan, goroutree.Int(4))
 
 			b = <-boolreschan
 			if b != true {
@@ -730,14 +730,14 @@ func TestDelete(t *testing.T) {
 			g := goroutree.New()
 			boolreschan := make(chan bool)
 
-			g.Insert(boolreschan, 4)
+			g.Insert(boolreschan, goroutree.Int(4))
 
 			b := <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Delete(boolreschan, 5)
+			g.Delete(boolreschan, goroutree.Int(5))
 
 			b = <-boolreschan
 			if b != false {
@@ -763,21 +763,21 @@ func TestDelete(t *testing.T) {
 			g := goroutree.New()
 			boolreschan := make(chan bool)
 
-			g.Insert(boolreschan, 4)
+			g.Insert(boolreschan, goroutree.Int(4))
 
 			b := <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 3)
+			g.Insert(boolreschan, goroutree.Int(3))
 
 			b = <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Delete(boolreschan, 3)
+			g.Delete(boolreschan, goroutree.Int(3))
 
 			b = <-boolreschan
 			if b != true {
@@ -801,21 +801,21 @@ func TestDelete(t *testing.T) {
 			g := goroutree.New()
 			boolreschan := make(chan bool)
 
-			g.Insert(boolreschan, 4)
+			g.Insert(boolreschan, goroutree.Int(4))
 
 			b := <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 5)
+			g.Insert(boolreschan, goroutree.Int(5))
 
 			b = <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Delete(boolreschan, 5)
+			g.Delete(boolreschan, goroutree.Int(5))
 
 			b = <-boolreschan
 			if b != true {
@@ -841,21 +841,21 @@ func TestDelete(t *testing.T) {
 				g := goroutree.New()
 				boolreschan := make(chan bool)
 
-				g.Insert(boolreschan, 4)
+				g.Insert(boolreschan, goroutree.Int(4))
 
 				b := <-boolreschan
 				if b != true {
 					t.Fatalf("Expected a true result from inserting")
 				}
 
-				g.Insert(boolreschan, 3)
+				g.Insert(boolreschan, goroutree.Int(3))
 
 				b = <-boolreschan
 				if b != true {
 					t.Fatalf("Expected a true result from inserting")
 				}
 
-				g.Delete(boolreschan, 4)
+				g.Delete(boolreschan, goroutree.Int(4))
 
 				b = <-boolreschan
 				if b != true {
@@ -880,21 +880,21 @@ func TestDelete(t *testing.T) {
 				g := goroutree.New()
 				boolreschan := make(chan bool)
 
-				g.Insert(boolreschan, 4)
+				g.Insert(boolreschan, goroutree.Int(4))
 
 				b := <-boolreschan
 				if b != true {
 					t.Fatalf("Expected a true result from inserting")
 				}
 
-				g.Insert(boolreschan, 5)
+				g.Insert(boolreschan, goroutree.Int(5))
 
 				b = <-boolreschan
 				if b != true {
 					t.Fatalf("Expected a true result from inserting")
 				}
 
-				g.Delete(boolreschan, 4)
+				g.Delete(boolreschan, goroutree.Int(4))
 
 				b = <-boolreschan
 				if b != true {
@@ -921,28 +921,28 @@ func TestDelete(t *testing.T) {
 			g := goroutree.New()
 			boolreschan := make(chan bool)
 
-			g.Insert(boolreschan, 4)
+			g.Insert(boolreschan, goroutree.Int(4))
 
 			b := <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 3)
+			g.Insert(boolreschan, goroutree.Int(3))
 
 			b = <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 5)
+			g.Insert(boolreschan, goroutree.Int(5))
 
 			b = <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Delete(boolreschan, 4)
+			g.Delete(boolreschan, goroutree.Int(4))
 
 			b = <-boolreschan
 			if b != true {
@@ -966,35 +966,35 @@ func TestDelete(t *testing.T) {
 			g := goroutree.New()
 			boolreschan := make(chan bool)
 
-			g.Insert(boolreschan, 4)
+			g.Insert(boolreschan, goroutree.Int(4))
 
 			b := <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 3)
+			g.Insert(boolreschan, goroutree.Int(3))
 
 			b = <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 6)
+			g.Insert(boolreschan, goroutree.Int(6))
 
 			b = <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 5)
+			g.Insert(boolreschan, goroutree.Int(5))
 
 			b = <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Delete(boolreschan, 4)
+			g.Delete(boolreschan, goroutree.Int(4))
 
 			b = <-boolreschan
 			if b != true {
@@ -1018,42 +1018,42 @@ func TestDelete(t *testing.T) {
 			g := goroutree.New()
 			boolreschan := make(chan bool)
 
-			g.Insert(boolreschan, 4)
+			g.Insert(boolreschan, goroutree.Int(4))
 
 			b := <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 3)
+			g.Insert(boolreschan, goroutree.Int(3))
 
 			b = <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 7)
+			g.Insert(boolreschan, goroutree.Int(7))
 
 			b = <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 5)
+			g.Insert(boolreschan, goroutree.Int(5))
 
 			b = <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Insert(boolreschan, 6)
+			g.Insert(boolreschan, goroutree.Int(6))
 
 			b = <-boolreschan
 			if b != true {
 				t.Fatalf("Expected a true result from inserting")
 			}
 
-			g.Delete(boolreschan, 4)
+			g.Delete(boolreschan, goroutree.Int(4))
 
 			b = <-boolreschan
 			if b != true {
@@ -1089,7 +1089,7 @@ func genTreeLevels(levels int) *goroutree.Goroutree {
 	boolreschan := make(chan bool)
 
 	for i := 0; i < levels; i++ {
-		g.Insert(boolreschan, i)
+		g.Insert(boolreschan, goroutree.Int(i))
 		<-boolreschan
 	}
 
@@ -1101,7 +1101,8 @@ func benchInsert(b *testing.B, levels int) {
 	g := genTreeLevels(levels)
 
 	for i := 0; i < b.N; i++ {
-		g.Insert(boolreschan, levels)
+		g.Insert(boolreschan, goroutree.Int(levels))
+
 		<-boolreschan
 	}
 }


### PR DESCRIPTION
- Still needs to use the error returned from the comparer in the actual tree (its being ignored).  How would you handle this?  In this case I'd either return the error up to the caller, or panic. depends on what you want.